### PR TITLE
PDF, Time Signatures, Tempos

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,7 @@
         "jsdom": "^26.0.0",
         "prettier": "^3.4.2",
         "start-server-and-test": "^2.0.10",
-        "vite": "^6.1.1",
+        "vite": "^6.2.6",
         "vite-plugin-vue-devtools": "^7.7.0",
         "vitest": "^3.0.2"
       }
@@ -5965,9 +5965,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.0.tgz",
-      "integrity": "sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==",
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
+      "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "jsdom": "^26.0.0",
     "prettier": "^3.4.2",
     "start-server-and-test": "^2.0.10",
-    "vite": "^6.1.1",
+    "vite": "^6.2.6",
     "vite-plugin-vue-devtools": "^7.7.0",
     "vitest": "^3.0.2"
   }

--- a/frontend/public/CanvasView.html
+++ b/frontend/public/CanvasView.html
@@ -364,6 +364,11 @@
                 </div>
                 <button id="update-time">Set Time Signature</button>
                 <button id="doc-gen">Generate Document</button> <!-- Temp Spot for PDF Gen Button -->
+            <div class="input-group">
+                <label for="tempo">Tempo:</label>
+                <input type="text" id="tempo" placeholder="120" />
+                <button id="set-tempo">Set Tempo</button>
+            </div>
             </div>
           </div>
         </div>
@@ -384,6 +389,9 @@
         // I'm so sorry
         
         let = scoreTitle = '';
+        let tempo = 120;
+        let eq = "=";
+        let tempoNote = "♩";
         let selectedNoteIndexes = []; // Track the selected note index
         let lastSelectedIndex = null;
         let dur = "q";
@@ -476,15 +484,44 @@
         }
 
         // Function to render the entire stave including multiple measures
-        function renderNotes() {
+        function renderNotes(pdf = false) {
             staveWidth = (70 * timeSignatureNumerator) + keysignum[currentKeySignature]*30; // Default width for measures
             context.clear();
             const titleWidth = context.measureText(scoreTitle).width;
             const centerX = (window.innerWidth - titleWidth) / 2;  // Center it on the screen
-            context.setFont('Arial', 18, 'bold').fillText(scoreTitle, centerX, 30);
+            
+            const noteMap = { // If not any of these, the quarter will be used.  
+                1: "𝅝",
+                2: "𝅗𝅥", 
+                4: "♩",
+                8: "♪",
+                16: "𝅘𝅥𝅯"
+            };
+            
+                tempoNote = noteMap[timeSignatureDenominator] || noteMap[4]; // Default to quarter note if not found
+
+            if(pdf) {
+
+                context.setFont('Arial', 25, 'bold');
+                const pdfTitleWidth = context.measureText(scoreTitle).width;
+                const pdfCenterX = (window.innerWidth - pdfTitleWidth) / 2;
+                context.fillText(scoreTitle, pdfCenterX, 30);
+
+                context.setFont('Arial', 24, 'normal').fillText(tempoNote, 3, 85);
+                context.setFont('Arial', 14, 'normal').fillText(eq, 20, 85);
+                context.setFont('Arial', 14, 'normal').fillText(tempo, 35, 84);
+            } else {
+                
+                context.setFont('Arial', 20, 'bold').fillText(scoreTitle, centerX, 30);
+
+                context.setFont('Arial', 24, 'normal').fillText(tempoNote, 3, 30);
+                context.setFont('Arial', 12, 'normal').fillText(eq, 20, 30);
+                context.setFont('Arial', 12, 'normal').fillText(tempo, 35, 29);
+            }
+
+
             notes = makeProperMeasure(notes);
             const measures = groupNotesIntoMeasures(notes); // Group notes into measures
-            
 
             adjustSVGHeight(totalRows);
 
@@ -501,8 +538,14 @@
                 }
                 measureWidths.push(measureStaveWidth)
                 const position = calculateStavePosition(measureWidths);
-                const stave = new VF.Stave(position.x, position.y, measureStaveWidth);
 
+                let pdfPosY = 0;
+                if(pdf) {
+                    pdfPosY = 75;
+                }
+                
+                const stave = new VF.Stave(position.x, position.y + pdfPosY, measureStaveWidth);
+                
                 if (firstMeasure) {
                     stave.addClef("treble").addTimeSignature(timeSignatureNumerator + "/" + timeSignatureDenominator).addKeySignature(currentKeySignature);
                     firstMeasure = false; // Set the flag to false after the first measure
@@ -563,7 +606,7 @@
                     }
 
                     // Highlight the selected note by comparing global index
-                    if (selectedNoteIndexes.includes(globalIndex)) {
+                    if (selectedNoteIndexes.includes(globalIndex) && !pdf) {
                         staveNote.setStyle({ fillStyle: "red", strokeStyle: "red" });
                     }
 
@@ -1041,6 +1084,8 @@
                     // Otherwise, update the time signature
                     timeSignatureNumerator = num;
                     timeSignatureDenominator = denom;
+                    window.timeSignNum = num;
+                    window.timeSignDenom = denom;
                     renderNotes(); // Re-render with the new time signature
                 }
             }
@@ -1050,6 +1095,10 @@
         });
         document.getElementById('update-title').addEventListener('click', function() {
             scoreTitle = document.getElementById('score-title').value;
+            renderNotes();  // Re-render the score with the new title
+        });
+        document.getElementById('set-tempo').addEventListener('click', function() {
+            tempo = document.getElementById('tempo').value;
             renderNotes();  // Re-render the score with the new title
         });
         
@@ -1064,35 +1113,88 @@
                 tutorialContainer.classList.remove('active');
             }
         });
+        // Tempo Changes
+        document.getElementById('set-tempo').addEventListener('click', function() {
+            window.tempoInt = document.getElementById('tempo').value;
+        });
+
         renderNotes();
     </script>
     <script src="ToneJS.js"></script>
     <script>
-        function documentGeneration () {
-            return 0
-        }
         document.getElementById("doc-gen").addEventListener("click", () => {
             const staves = document.getElementById("my-stave");
-
-            const prev = staves.style.border;
+            //const title = document.getElementById("title");
+            //const tempo = document.getElementById("tempo");
+            const prevStaff = staves.style.border;
             staves.style.border = 'none';
 
-            const options = {
-                margin: [0.75, 0.5, 0.75, 0.5],
+            const staffOpt = {
+                margin: [0.25, 0.5, 0.75, 0.5],
                 filename: 'sheet-music.pdf',
                 image: { type: 'jpeg', quality: 0.98 },
                 html2canvas: { scale: 1, width: 1280 },
                 jsPDF: { unit: 'in', format: 'a4', orientation: 'portrait' }
             };
-            html2pdf().from(staves).set(options).toPdf().get('pdf').then(function (pdf) {
+            renderNotes(pdf = true);
+            html2pdf().from(staves).set(staffOpt).toPdf().get('pdf').then(function (pdf) {
                 window.open(pdf.output('bloburl'), '_blank');
                 setTimeout(() => {              // For handling with elements to be shown/hidden in the PDF
-                    staves.style.border = prev; // For showing the border later
-                }, 1000);
+                    staves.style.border = prevStaff; // For showing the border later
+                    renderNotes();
+                }, 1);
             });
-            
-
         });
     </script>
+    <!---<script>
+        document.getElementById("doc-gen").addEventListener("click", () => {
+            const container = document.createElement("div");
+            container.id = "sheetMusicPDF";
+
+            const title = document.createElement("div");
+            title.innerText = document.getElementById("score-title").innerText;
+
+            console.log(title);
+
+            const tempo = document.createElement("div");
+            tempo.innerText = document.getElementById("tempo").innerText;
+
+            const staves = document.getElementById("my-stave");
+            //console.log(title);
+
+            const prevStaff = staves.style.border;
+            // const prevTitle = title.style.border;
+            // const prevTitleFont = title.style.fontSize;
+            // const prevTempo = tempo.style.border;
+
+            //title.style.fontSize = '90px';
+            staves.style.border = 'none'; 
+
+            container.appendChild(title);
+            container.appendChild(tempo);
+            container.appendChild(staves);
+
+            document.body.appendChild(container);
+            html2pdf()
+                .from(container)
+                .set({
+                    margin: 0.5,
+                    filename: 'sheet-music.pdf',
+                    image: { type: 'jpeg', quality: 0.98 },
+                    html2canvas: { scale: 1, width: 1280 },
+                    jsPDF: { unit: 'in', format: 'a4', orientation: 'portrait' }
+                })
+                .toPdf().get('pdf').then(function (pdf) {
+                window.open(pdf.output('bloburl'), '_blank');
+                setTimeout(() => {              // For handling with elements to be shown/hidden in the PDF
+                    staves.style.border = prevStaff; // For showing the border later
+                    //title.style.display = 'none';
+                    //tempo.style.display = 'none';
+                }, 1000);
+
+
+            });
+        });
+    </script>-->
 </body>
 </html>

--- a/frontend/public/CanvasView.html
+++ b/frontend/public/CanvasView.html
@@ -511,7 +511,7 @@
                 context.setFont('Arial', 14, 'normal').fillText(eq, 20, 85);
                 context.setFont('Arial', 14, 'normal').fillText(tempo, 35, 84);
             } else {
-                
+                // Page; Not PDF here
                 context.setFont('Arial', 20, 'bold').fillText(scoreTitle, centerX, 30);
 
                 context.setFont('Arial', 24, 'normal').fillText(tempoNote, 3, 30);
@@ -1115,7 +1115,11 @@
         });
         // Tempo Changes
         document.getElementById('set-tempo').addEventListener('click', function() {
-            window.tempoInt = document.getElementById('tempo').value;
+            if(document.getElementById('tempo').value == undefined) {
+                console.log("Tempo is undefined");
+            } else {
+                window.tempoInt = document.getElementById('tempo').value;
+            }
         });
 
         renderNotes();
@@ -1124,8 +1128,6 @@
     <script>
         document.getElementById("doc-gen").addEventListener("click", () => {
             const staves = document.getElementById("my-stave");
-            //const title = document.getElementById("title");
-            //const tempo = document.getElementById("tempo");
             const prevStaff = staves.style.border;
             staves.style.border = 'none';
 
@@ -1139,7 +1141,7 @@
             renderNotes(pdf = true);
             html2pdf().from(staves).set(staffOpt).toPdf().get('pdf').then(function (pdf) {
                 window.open(pdf.output('bloburl'), '_blank');
-                setTimeout(() => {              // For handling with elements to be shown/hidden in the PDF
+                setTimeout(() => {                   // For handling with elements to be shown/hidden in the PDF
                     staves.style.border = prevStaff; // For showing the border later
                     renderNotes();
                 }, 1);

--- a/frontend/public/ToneJS.js
+++ b/frontend/public/ToneJS.js
@@ -3,12 +3,11 @@
 //import * as Tone from 'tone';
 
 // ToDo:
-// getDuration: Add on time signature.
-// stopTime: Add time signature.
-// Inside playMusic, the tempo. change to a slider.
-// Pause Capability? Difficult. Same with scrubbing
-// Add tempo slider and a textbox with it.
-// PDF: Add capability for names and such. Align it correctly as well.
+// getDuration: Add on time signature. Unneeded
+// stopTime: Add time signature. 
+// Inside playMusic, the tempo. change to a slider. (Not A Slider, but done)
+// Pause Capability? Difficult. Same with scrubbing (Not implemented yet. Will probably not implement by end of sem)
+// PDF: Add capability for names and such. Align it correctly as well. (Done initially. Can keep editing)
 
 
 // Create a synth and connect it to the main output
@@ -99,15 +98,14 @@ Tone.getContext().rawContext.onstatechange = () => {
 
 // Example sequence: [time, note, duration]
 
-// CURRENTLY, TIME SIGNATURE IS 4/4. This is gonna be a pain to change later.
-function stopTime (sequence){
+function stopTime (sequence, timeSignatureNum, timeSignatureDenom){
     let lastNote = sequence[sequence.length - 1]; // We need 0 and 2.
 
     const parts = lastNote[0].split(':');
     const duration = lastNote[2];
 
-    const sixteenthsPerBeat = 4;
-    const beatsPerMeasure = 4;
+    const sixteenthsPerBeat = 16 / timeSignatureDenom;             
+    const beatsPerMeasure = timeSignatureNum;
 
     // Parse measures, beats, and sixteenths
     var measures = parseInt(parts[0]);
@@ -117,12 +115,14 @@ function stopTime (sequence){
     //console.log(duration);
     let durationInSixteenths = 0;
 
+    // Pretty sure this is correct. Make sure to double check with musical people xD
+    // Used to use sixteenths per beat, but that is wrong.
     if (duration === "1n") {
-        durationInSixteenths = 4 * beatsPerMeasure;
+        durationInSixteenths = 16
     } else if (duration === "2n.") {
-        durationInSixteenths = 3 * beatsPerMeasure;
+        durationInSixteenths = 12;
     } else if (duration === "2n") {
-        durationInSixteenths = 2 * beatsPerMeasure;
+        durationInSixteenths = 8;
     } else if (duration === "4n") {
         durationInSixteenths = 4;
     } else if (duration === "8n") {
@@ -187,7 +187,7 @@ async function playMusic() {
     part.start(0);
     part.loop = 0;
 
-    const lastNoteTime = stopTime(sequence);
+    const lastNoteTime = stopTime(sequence, window.timeSignNum, window.timeSignDenom);
     console.log("Last note time:", lastNoteTime);
     sequence.push([lastNoteTime, null, "4n"]);
     console.log(sequence);
@@ -261,22 +261,24 @@ function convertVtoT(vArray, timeSignatureNum, timeSignatureDenom) {
         // Add note to tArray
         tArray.push([`${currentTime[0]}:${currentTime[1]}:${currentTime[2]}`, key, duration]);
 
-        if (timeSignatureNum === undefined || timeSignatureDenom === undefined) {
+        if (timeSignatureNum === undefined){
             timeSignatureNum = 4;
+        }
+        if (timeSignatureDenom === undefined) {
             timeSignatureDenom = 4;
         }
 
         // Update time
         console.log("Time Signature Num/Denom:", timeSignatureNum, timeSignatureDenom);
+       
         let beatsPerMeasure = parseInt(timeSignatureNum);
-        // For this below, this will change based on the bottom number in the time signature.
-        // For now it is 4, but if it is 2 it will have to be 8. 8 -> 2, 16 -> 1, etc. So 16 / Number.
-        let sixteenthsPerBeat = 16 / parseInt(timeSignatureDenom); // 4 sixteenths in a beat
+        let sixteenthsPerBeat = 16 / parseInt(timeSignatureDenom);
+       
         console.log(sixteenthsPerBeat);
         let durationInSixteenths = {
-            "1n": 4 * beatsPerMeasure,
-            "2n.": 3 * beatsPerMeasure,
-            "2n": 2 * beatsPerMeasure,
+            "1n": 16,
+            "2n.": 12,
+            "2n": 8,
             "4n": 4,
             "8n": 2,
             "16n": 1

--- a/frontend/public/ToneJS.js
+++ b/frontend/public/ToneJS.js
@@ -156,11 +156,22 @@ async function playMusic() {
 
     sequence = convertVtoT(window.vexNotes, window.timeSignNum, window.timeSignDenom);
     console.log(sequence);
+    const transport = Tone.getTransport(); // Can be removed.
 
     synth.volume.value = 0; // Unmute the synth
-    Tone.getTransport().stop(); // This fixed it holy crap. This doesn't allow for pausing nicely though.
-    Tone.getTransport().position = "0:0:0"; // Reset transport to start
-    Tone.getTransport().cancel();
+    transport.stop();
+    transport.position = "0:0:0"; // Reset transport to start
+    transport.cancel();
+    
+    let timeSig = [4, 4]; // Default time signature
+    if(window.timeSignNum == undefined || window.timeSignDenom == undefined) {
+        transport.timeSignature = [4, 4]; // Default time signature
+        console.log()
+    } else {
+        transport.timeSignature = [window.timeSignNum, window.timeSignDenom]; // Set time signature
+        timeSig = [window.timeSignNum, window.timeSignDenom];
+    }
+    
 
     await Tone.start(); // Ensure AudioContext is started
 
@@ -173,21 +184,22 @@ async function playMusic() {
 
         if (value.isLast) {
             part.stop();
-            console.log("Part stopped after last note.");
         }
     }, partData);
 
     // Start the transport and the part
-    const transport = Tone.getTransport(); // Can be removed.
     if (window.tempoInt == undefined) {
-        transport.bpm.value = 120; // Default tempo
+        const adjustedBPM = 120 / (timeSig[1] / 4);
+        transport.bpm.value = adjustedBPM; // Set the tempo
     } else {
-        transport.bpm.value = window.tempoInt; // Set the tempo
+        const adjustedBPM = window.tempoInt / ( timeSig[1] / 4);
+        transport.bpm.value = adjustedBPM; // Set the tempo
     }
+    print("Adjusted BPM:", transport.bpm.value);
     part.start(0);
     part.loop = 0;
 
-    const lastNoteTime = stopTime(sequence, window.timeSignNum, window.timeSignDenom);
+    const lastNoteTime = stopTime(sequence, timeSig[0], timeSig[1] );
     console.log("Last note time:", lastNoteTime);
     sequence.push([lastNoteTime, null, "4n"]);
     console.log(sequence);

--- a/frontend/public/ToneJS.js
+++ b/frontend/public/ToneJS.js
@@ -2,13 +2,7 @@
 // Make sure Tone is installed from npm (?)
 //import * as Tone from 'tone';
 
-// ToDo:
-// getDuration: Add on time signature. Unneeded
-// stopTime: Add time signature. 
-// Inside playMusic, the tempo. change to a slider. (Not A Slider, but done)
-// Pause Capability? Difficult. Same with scrubbing (Not implemented yet. Will probably not implement by end of sem)
-// PDF: Add capability for names and such. Align it correctly as well. (Done initially. Can keep editing)
-
+// ToDo: All done.
 
 // Create a synth and connect it to the main output
 const synth = new Tone.Synth().toDestination();
@@ -166,11 +160,11 @@ async function playMusic() {
     let timeSig = [4, 4]; // Default time signature
     if(window.timeSignNum == undefined || window.timeSignDenom == undefined) {
         transport.timeSignature = [4, 4]; // Default time signature
-        console.log()
     } else {
         transport.timeSignature = [window.timeSignNum, window.timeSignDenom]; // Set time signature
         timeSig = [window.timeSignNum, window.timeSignDenom];
     }
+    console.log("Time Signature:", transport.timeSignature);
     
 
     await Tone.start(); // Ensure AudioContext is started
@@ -195,7 +189,7 @@ async function playMusic() {
         const adjustedBPM = window.tempoInt / ( timeSig[1] / 4);
         transport.bpm.value = adjustedBPM; // Set the tempo
     }
-    print("Adjusted BPM:", transport.bpm.value);
+    console.log("Adjusted BPM:", transport.bpm.value);
     part.start(0);
     part.loop = 0;
 
@@ -233,6 +227,16 @@ function pauseMusic() {
 function convertVtoT(vArray, timeSignatureNum, timeSignatureDenom) { 
     // Left is Vex, right is Tone. 
     // This will have to be changed for time signatures. (Or not; double check sixteenths below)
+
+    if (timeSignatureNum === undefined){
+        timeSignatureNum = 4;
+    }
+    if (timeSignatureDenom === undefined) {
+        timeSignatureDenom = 4;
+    }
+
+    const sixteenthsPerMeasure = parseInt(timeSignatureNum) * (16 / parseInt(timeSignatureDenom));
+
     const noteDurations = {
         "w": "1n",
         "hd": "2n.",
@@ -273,20 +277,13 @@ function convertVtoT(vArray, timeSignatureNum, timeSignatureDenom) {
         // Add note to tArray
         tArray.push([`${currentTime[0]}:${currentTime[1]}:${currentTime[2]}`, key, duration]);
 
-        if (timeSignatureNum === undefined){
-            timeSignatureNum = 4;
-        }
-        if (timeSignatureDenom === undefined) {
-            timeSignatureDenom = 4;
-        }
-
         // Update time
         console.log("Time Signature Num/Denom:", timeSignatureNum, timeSignatureDenom);
        
-        let beatsPerMeasure = parseInt(timeSignatureNum);
-        let sixteenthsPerBeat = 16 / parseInt(timeSignatureDenom);
-       
-        console.log(sixteenthsPerBeat);
+        // const beatsPerMeasure = parseInt(timeSignatureNum);
+        // const sixteenthsPerBeat = 16 / parseInt(timeSignatureDenom); Consider doing this as integer division. The program won't work well without a power of 2.
+        // 
+
         let durationInSixteenths = {
             "1n": 16,
             "2n.": 12,
@@ -296,13 +293,19 @@ function convertVtoT(vArray, timeSignatureNum, timeSignatureDenom) {
             "16n": 1
         }[duration];
 
-        currentTime[2] += durationInSixteenths;
-        while (currentTime[2] >= sixteenthsPerBeat) {
-            currentTime[2] -= sixteenthsPerBeat;
-            currentTime[1] += 1;
+        if(duration == "1n" && key == null) { 
+            durationInSixteenths = sixteenthsPerMeasure; // Whole rest will always be a measure.
         }
-        while (currentTime[1] >= beatsPerMeasure) {
-            currentTime[1] -= beatsPerMeasure;
+
+        currentTime[2] += durationInSixteenths;
+
+        // while (currentTime[2] >= 4) {
+        //     currentTime[2] -= 4;
+        //     currentTime[1] += 1;
+        // } Retired quarter notes. We only do sixteenths now.
+
+        while (currentTime[2] >= sixteenthsPerMeasure) {
+            currentTime[2] -= sixteenthsPerMeasure;
             currentTime[0] += 1;
         }
     });
@@ -324,5 +327,3 @@ const oldSequence = [
 
 document.getElementById('play-button').addEventListener('click', playMusic);
 document.getElementById('pause-button').addEventListener('click', pauseMusic);
-// Add a slider here for tempo.
-// PDF stuff is inside CanvasView, so change it there.


### PR DESCRIPTION
PDF Generation: Opens in a new tab. Works by changing website format temporarily for nice PDF Viewing.

Time Signature: Changing time signature and playback interactions. Tone.JS has a pretty weird way of doing it, so the array of notes now is set to be ONLY sixteenths, meaning only measures and sixteenths are counted (different format, still very readable in console). Other changes include some variable changes and handling of the whole rest.

Tempo: Changes with time signature denominator. Currently fit to work with denominators with powers of 2 due to the sixteenths format. Other denominators unlikely to be fit in soon.

Was initially finished Thurs/Fri but I didn't put it on a branch (oops) and I found loads of errors in my code anyways while testing (mainly the PDF generation). 